### PR TITLE
Remove legacy no-use-before-declare rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -156,7 +156,7 @@ module.exports = {
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
+    "no-use-before-declare": false,
     "no-var-keyword": true,
     "one-line": [
       true,


### PR DESCRIPTION
See https://palantir.github.io/tslint/rules/no-use-before-declare/:

> This rule is primarily useful when using the var keyword since the compiler will automatically detect if a block-scoped let and const variable is used before declaration. Since most modern TypeScript doesn’t use var, this rule is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions.